### PR TITLE
Some progress towards a 64-bit docker container

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -97,7 +97,7 @@ RUN update-java-alternatives --set /usr/lib/jvm/java-1.11.0-openjdk-amd64
 USER user
 
 # Environment variables
-ENV JAVA_HOME           /usr/lib/jvm/default-java
+ENV JAVA_HOME           /usr/lib/jvm/java-11-openjdk-amd64
 ENV HOME                /home/user
 ENV CONTIKI_NG          ${HOME}/contiki-ng
 ENV COOJA               ${CONTIKI_NG}/tools/cooja

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -41,10 +41,10 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN npm -q install coap-cli@0.5.1 -g
 
 # Install ARM toolchain
-RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa
-RUN apt-get update \
-    && apt-get -y install 'gcc-arm-embedded=7-2018q2-1~bionic*' \
-    && apt-get -qq clean
+RUN wget -nv https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 && \
+  tar xjf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 -C /tmp/ && \
+  cp -f -r /tmp/gcc-arm-none-eabi-9-2019-q4-major/* /usr/local/ && \
+  rm -rf /tmp/gcc-arm-none-eabi-* gcc-arm-none-eabi-*-linux.tar.bz2
 
 # Install msp430 toolchain
 RUN wget -nv http://simonduq.github.io/resources/mspgcc-4.7.2-compiled.tar.bz2 && \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -101,6 +101,9 @@ RUN export uid=1000 gid=1000 && \
     chown ${uid}:${gid} -R /home/user && \
     usermod -aG dialout user
 
+# Set java 11 for Cooja
+RUN update-java-alternatives --set /usr/lib/jvm/java-1.11.0-openjdk-amd64
+
 # Set user for what comes next
 USER user
 
@@ -115,9 +118,6 @@ WORKDIR                 ${HOME}
 # Create Cooja shortcut
 RUN echo "#!/bin/bash\nant -Dbasedir=${COOJA} -f ${COOJA}/build.xml run" > ${HOME}/cooja && \
   chmod +x ${HOME}/cooja
-
-# Set java 11 for Cooja
-RUN sudo update-java-alternatives --set /usr/lib/jvm/java-1.11.0-openjdk-amd64
 
 # By default, we use a Docker bind mount to share the repo with the host,
 # with Docker run option:

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -13,7 +13,6 @@ RUN apt-get -qq update \
 RUN apt-get update && apt-get -y --no-install-recommends install \
     ant \
     build-essential \
-    default-jdk \
     doxygen \
     gdb \
     git \
@@ -27,7 +26,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     mosquitto-clients \
     net-tools \
     npm \
-    openjdk-8-jdk \
+    openjdk-11-jdk \
     python-pip \
     python-serial \
     rlwrap \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -119,13 +119,6 @@ RUN echo "#!/bin/bash\nant -Dbasedir=${COOJA} -f ${COOJA}/build.xml run" > ${HOM
 # Set java 11 for Cooja
 RUN sudo update-java-alternatives --set /usr/lib/jvm/java-1.11.0-openjdk-amd64
 
-# Download, build and install Renode
-RUN git clone --quiet https://github.com/renode/renode.git \
-  && cd ${HOME}/renode \
-  && git checkout v1.3 \
-  && ./build.sh
-ENV PATH="${HOME}/renode:${PATH}"
-
 # By default, we use a Docker bind mount to share the repo with the host,
 # with Docker run option:
 # -v <HOST_CONTIKI_NG_ABS_PATH>:/home/user/contiki-ng

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -95,8 +95,8 @@ RUN update-java-alternatives --set /usr/lib/jvm/java-1.11.0-openjdk-amd64
 
 # Install 32-bit support for the msp430 and jn516x toolchains
 RUN dpkg --add-architecture i386 && \
-    apt update && \
-    apt install -y --no-install-recommends libc6:i386 zlib1g:i386
+    apt-get update && \
+    apt-get install -y --no-install-recommends libc6:i386 zlib1g:i386
 
 # Set user for what comes next
 USER user

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -10,10 +10,7 @@ RUN apt-get -qq update \
     && apt-get -qq -y --no-install-recommends install apt-utils gnupg > /dev/null \
     && apt-get -qq clean
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
-  echo "deb http://download.mono-project.com/repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/mono-xamarin.list && \
-  apt-get -qq update && \
-  apt-get -qq -y --no-install-recommends install \
+RUN apt-get update && apt-get -y --no-install-recommends install \
     ant \
     build-essential \
     default-jdk \
@@ -45,7 +42,6 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
     smitools \
     snmp \
     snmp-mibs-downloader \
-    > /dev/null \
   && apt-get -qq clean
 
 # Install coap-cli

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -93,6 +93,11 @@ RUN export uid=1000 gid=1000 && \
 # Set java 11 for Cooja
 RUN update-java-alternatives --set /usr/lib/jvm/java-1.11.0-openjdk-amd64
 
+# Install 32-bit support for the msp430 and jn516x toolchains
+RUN dpkg --add-architecture i386 && \
+    apt update && \
+    apt install -y --no-install-recommends libc6:i386 zlib1g:i386
+
 # Set user for what comes next
 USER user
 

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -16,12 +16,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     doxygen \
     gdb \
     git \
-    gtk-sharp2 \
     iputils-tracepath \
     iputils-ping \
-    libcanberra-gtk-module \
-    libgtk2.0-0 \
-    mono-complete \
     mosquitto \
     mosquitto-clients \
     net-tools \
@@ -31,10 +27,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     python-serial \
     rlwrap \
     sudo \
-    screen \
     srecord \
     software-properties-common \
-    uml-utilities \
     unzip \
     valgrind \
     wget \


### PR DESCRIPTION
Hi Simon

See some patches in this PR:

* I have changed the way we set java
* I have added support for 32-bit toolchains (msp430 and NXP)
* I have changed the way we install arm-gcc: I reverted to downloading using wget, but this time from developer.arm.com

I have disabled building renode to speed up container creation. Since we are not building renode, I removed mono-related apt packages. This will need more work at some point, but I think for testing purposes we are good. It is most likely we'll end up having to include the latest renode version in the container anyway, so some changes will most likely be required.